### PR TITLE
Check for database table existance

### DIFF
--- a/assets/.htaccess
+++ b/assets/.htaccess
@@ -1,2 +1,7 @@
-order deny,allow
-allow from all
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>

--- a/classes/DirectEntryArticle.php
+++ b/classes/DirectEntryArticle.php
@@ -51,13 +51,27 @@ class DirectEntryArticle extends \Backend
                     // check page permission
                     if($this->User->isAdmin || in_array($objPages->id, $this->User->pagemounts))
                     {
+                        if(version_compare(VERSION, '3.5', '<'))
+                        {
+                            $strQuery = http_build_query([
+                                'do'   => 'article',
+                                'node' => $objPages->id,
+                            ]);
+                        } else {
+                            $strQuery = http_build_query([
+                                'do'   => 'article',
+                                'node' => $objPages->id,
+                                'pn'   => $objPages->id,
+                            ]);
+                        }
+
                         // set the icon url and title
-                        $arrDirectEntry[$intCounter]['icons']['page']['url'] = 'contao/main.php?do=article&node=' . $objPages->id;
+                        $arrDirectEntry[$intCounter]['icons']['page']['url'] = 'contao/main.php?' . $strQuery;
                         $arrDirectEntry[$intCounter]['icons']['page']['title'] = 'page';
                         $arrDirectEntry[$intCounter]['icons']['page']['icon'] = 'article';
 
                         // set the page url and title
-                        $arrDirectEntry[$intCounter]['name']['url'] = 'contao/main.php?do=article&node=' . $objPages->id;
+                        $arrDirectEntry[$intCounter]['name']['url'] = 'contao/main.php?' . $strQuery;
                         $arrDirectEntry[$intCounter]['name']['title'] = $objPages->title;
                         $arrDirectEntry[$intCounter]['name']['link'] = strlen($objPages->title) > 17 ? substr($objPages->title, 0, 15) . '...' : $objPages->title;
 

--- a/classes/DirectEntryArticle.php
+++ b/classes/DirectEntryArticle.php
@@ -30,6 +30,9 @@ class DirectEntryArticle extends \Backend
         // check permission
         if($this->User->isAdmin || ($this->User->hasAccess('article', 'modules') && isset($this->User->pagemounts) && is_array($this->User->pagemounts)))
         {
+            // check if table exists
+            if (!$this->Database->tableExists('tl_article')) return;
+
             // get all existing root pages
             $objPages = \PageModel::findBy('type', 'root', array('order' => 'title'));
 

--- a/classes/DirectEntryCalendar.php
+++ b/classes/DirectEntryCalendar.php
@@ -33,6 +33,9 @@ class DirectEntryCalendar extends \Backend
             // check permission
             if($this->User->isAdmin || ($this->User->hasAccess('calendar', 'modules') && isset($this->User->calendars) && is_array($this->User->calendars)))
             {
+                // check if table exists
+                if (!$this->Database->tableExists('tl_calendar')) return;
+
                 // get all existing root pages
                 $objCalendar = \CalendarModel::findAll(array('order' => 'title'));
 

--- a/classes/DirectEntryFaq.php
+++ b/classes/DirectEntryFaq.php
@@ -33,6 +33,9 @@ class DirectEntryFaq extends \Backend
             // check permission
             if($this->User->isAdmin || ($this->User->hasAccess('faq', 'modules') && isset($this->User->faqs) && is_array($this->User->faqs)))
             {
+                // check if table exists
+                if (!$this->Database->tableExists('tl_faq')) return;
+
                 // get all faq categories
                 $objFaq = \FaqCategoryModel::findAll(array('order' => 'title'));
 

--- a/classes/DirectEntryForm.php
+++ b/classes/DirectEntryForm.php
@@ -30,6 +30,9 @@ class DirectEntryForm extends \Backend
         // check permission
         if($this->User->isAdmin || ($this->User->hasAccess('form', 'modules') && isset($this->User->forms) && is_array($this->User->forms)))
         {
+            // check if table exists
+            if (!$this->Database->tableExists('tl_form')) return;
+
             // get all forms
             $objForm = \FormModel::findAll(array('order' => 'title'));
 

--- a/classes/DirectEntryNews.php
+++ b/classes/DirectEntryNews.php
@@ -33,6 +33,9 @@ class DirectEntryNews extends \Backend
             // check permission
             if($this->User->isAdmin || ($this->User->hasAccess('news', 'modules') && isset($this->User->news) && is_array($this->User->news)))
             {
+                // check if table exists
+                if (!$this->Database->tableExists('tl_news')) return;
+
                 // get all news archives
                 $objNews = \NewsArchiveModel::findAll(array('order' => 'title'));
 

--- a/classes/DirectEntryNewsletter.php
+++ b/classes/DirectEntryNewsletter.php
@@ -33,6 +33,9 @@ class DirectEntryNewsletter extends \Backend
             // check permission
             if($this->User->isAdmin || ($this->User->hasAccess('newsletter', 'modules') && isset($this->User->newsletters) && is_array($this->User->newsletters)))
             {
+                // check if table exists
+                if (!$this->Database->tableExists('tl_newsletter')) return;
+
                 // get all newsletter channels
                 $objNewsletter = \NewsletterChannelModel::findAll(array('order' => 'title'));
 

--- a/classes/DirectEntryPage.php
+++ b/classes/DirectEntryPage.php
@@ -51,13 +51,27 @@ class DirectEntryPage extends \Backend
                     // check page permission
                     if($this->User->isAdmin || in_array($objPages->id, $this->User->pagemounts))
                     {
+                        if(version_compare(VERSION, '3.5', '<'))
+                        {
+                            $strQuery = http_build_query([
+                                'do'   => 'page',
+                                'node' => $objPages->id,
+                            ]);
+                        } else {
+                            $strQuery = http_build_query([
+                                'do'   => 'page',
+                                'node' => $objPages->id,
+                                'pn'   => $objPages->id,
+                            ]);
+                        }
+
                         // set the icon url and title
-                        $arrDirectEntry[$intCounter]['icons']['page']['url'] = 'contao/main.php?do=page&node=' . $objPages->id;
+                        $arrDirectEntry[$intCounter]['icons']['page']['url'] = 'contao/main.php?' . $strQuery;
                         $arrDirectEntry[$intCounter]['icons']['page']['title'] = 'page';
                         $arrDirectEntry[$intCounter]['icons']['page']['icon'] = 'page';
 
                         // set the page url and title
-                        $arrDirectEntry[$intCounter]['name']['url'] = 'contao/main.php?do=page&node=' . $objPages->id;
+                        $arrDirectEntry[$intCounter]['name']['url'] = 'contao/main.php?' . $strQuery;
                         $arrDirectEntry[$intCounter]['name']['title'] = $objPages->title;
                         $arrDirectEntry[$intCounter]['name']['link'] = strlen($objPages->title) > 17 ? substr($objPages->title, 0, 15) . '...' : $objPages->title;
 

--- a/classes/DirectEntryPage.php
+++ b/classes/DirectEntryPage.php
@@ -30,6 +30,9 @@ class DirectEntryPage extends \Backend
         // check permission
         if($this->User->isAdmin || ($this->User->hasAccess('page', 'modules') && isset($this->User->pagemounts) && is_array($this->User->pagemounts)))
         {
+            // check if table exists
+            if (!$this->Database->tableExists('tl_page')) return;
+
             // get all existing root pages
             $objPages = \PageModel::findBy('type', 'root', array('order' => 'title'));
 

--- a/classes/DirectEntryThemes.php
+++ b/classes/DirectEntryThemes.php
@@ -30,6 +30,9 @@ class DirectEntryThemes extends \Backend
         // check permission
         if($this->User->isAdmin || $this->User->hasAccess('themes', 'modules'))
         {
+            // check if table exists
+            if (!$this->Database->tableExists('tl_theme')) return;
+
             // get all existing themes
             $objThemes = \ThemeModel::findAll(array('order' => 'name'));
 

--- a/library/DirectEntries.php
+++ b/library/DirectEntries.php
@@ -235,7 +235,7 @@ class DirectEntries
     protected function _addContent($strGroup, $strItem, $strPreparedDirectEntry)
     {
         // regular expression pattern
-        $strPattern = '/(id\="tl_navigation"[\s\S]*?id\="' . $strGroup . '"[\s\S]*?class\=".*?' . $strItem . '.*?a\>)/';
+        $strPattern = '/(id\="tl_navigation"[\s\S]*?id\="' . $strGroup . '"[\s\S]*?class\="[^"]*?' . $strItem . '.*?a\>)/';
 
         // add html after thw wished link
         $this->_strContent = preg_replace($strPattern, '${1}' . $strPreparedDirectEntry, $this->_strContent);


### PR DESCRIPTION
Under special circumstances (when having deactivated extensions, their tables removed and then enabling them again) the directentries extension can render the system unusable.
